### PR TITLE
Create outline for bottom portion of main dashboard

### DIFF
--- a/src/components/main-dashboard/MainDashboard.jsx
+++ b/src/components/main-dashboard/MainDashboard.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import DailyWeather from './DailyWeather';
 import WelcomeHeader from './WelcomeHeader';
 import WeatherDetailTop from './WeatherDetailTop';
+import WeatherDetailBottom from './WeatherDetailBottom';
 
 export default function MainDashboard() {
   return (
@@ -9,6 +10,7 @@ export default function MainDashboard() {
       <WelcomeHeader />
       <DailyWeather />
       <WeatherDetailTop />
+      <WeatherDetailBottom />
     </section>
   );
 }

--- a/src/components/main-dashboard/WeatherDetailBottom.jsx
+++ b/src/components/main-dashboard/WeatherDetailBottom.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Pressure from './weather-details/Pressure';
+import WindStatus from './weather-details/WindStatus';
+import Humidity from './weather-details/Humidity';
+
+export default function WeatherDetailBottom() {
+  return (
+    <div className="row px-2">
+      <Pressure />
+      <WindStatus />
+      <Humidity />
+    </div>
+  );
+}

--- a/src/components/main-dashboard/weather-details/Humidity.jsx
+++ b/src/components/main-dashboard/weather-details/Humidity.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Humidity() {
+  return (
+    <div className="col-4 border border-primary rounded">
+      <h1>Humidity</h1>
+    </div>
+  );
+}

--- a/src/components/main-dashboard/weather-details/Pressure.jsx
+++ b/src/components/main-dashboard/weather-details/Pressure.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Pressure() {
+  return (
+    <div className="col-4 border border-primary rounded">
+      <h1>Pressure</h1>
+    </div>
+  );
+}

--- a/src/components/main-dashboard/weather-details/WindStatus.jsx
+++ b/src/components/main-dashboard/weather-details/WindStatus.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function WindStatus() {
+  return (
+    <div className="col-4 border border-primary rounded">
+      <h1>Wind Status</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
# New Features / Changes I Made
1. Create outline for the bottom half of the main dashboard.

### `WeatherDetailBottom`
- Create a simple outline of what the bottom portion of the main dashboard will look like. Styled using Bootstrap grid.

### `WeatherDetail`
- Added `Pressure`, `WindStatus`, and `Humidity` components which will be the details that are displayed for this bottom portion.


The outline helps with the structure and how much "space" I have to work with. I'd rather add the outline for the components I intend to create now rather than later when I'm implementing them b/c it will make future PR's cleaner.

# What Feedback I'm Looking For
Following the project guidelines, I'd appreciate any feedback on:
 - **Accessibility**
 - **Responsiveness**
 - **Airbnb style guide rules**
 - **Unnecessary code**
 - **Proper and consistent formatting**
 
***